### PR TITLE
Add credits page and link from login

### DIFF
--- a/src/server/nrp-site/index.js
+++ b/src/server/nrp-site/index.js
@@ -14,6 +14,39 @@ require("dotenv").config();
 
 const authRouter = require("./auth");
 
+const creditsSummary =
+  "Meet the volunteers keeping the GeoFS Naval Response Program running.";
+
+const creditsGroups = [
+  {
+    title: "Client-side Development",
+    description: "GeoFS addon scripts and interface engineering.",
+    members: [
+      {
+        name: "meatbroc",
+        role: "Client-side Developer",
+        contribution: "GeoFS Addon Script and Chrome extension work."
+      },
+      {
+        name: "delta_one",
+        role: "Client-side Developer",
+        contribution: "GeoFS Addon Script and interface refinements."
+      }
+    ]
+  },
+  {
+    title: "Infrastructure & Operations",
+    description: "Hosting and operational support for the program backend.",
+    members: [
+      {
+        name: "Osprey_",
+        role: "Infrastructure Lead",
+        contribution: "Server hosting and deployment management."
+      }
+    ]
+  }
+];
+
 /**
  * App Variables
  */
@@ -112,6 +145,14 @@ app.get("/", (req, res) => {
     return res.redirect("/admin-panel");
   }
   res.render("index", { title: "Home" });
+});
+
+app.get("/credits", (req, res) => {
+  res.render("credits", {
+    title: "Credits",
+    summary: creditsSummary,
+    creditsGroups
+  });
 });
 
 /**

--- a/src/server/nrp-site/public/style.css
+++ b/src/server/nrp-site/public/style.css
@@ -160,6 +160,173 @@ main.login-page {
   transform: translateY(0);
 }
 
+.login-meta {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.login-credits-link {
+  color: var(--accent-blue);
+  font-weight: 500;
+}
+
+.login-credits-link:hover {
+  color: #79c0ff;
+}
+
+main.credits-page {
+  width: 100%;
+  max-width: 760px;
+}
+
+.credits-card {
+  position: relative;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 40px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  box-shadow: 0 32px 60px rgba(1, 4, 9, 0.6);
+  overflow: hidden;
+}
+
+.credits-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      160deg,
+      rgba(88, 166, 255, 0.15),
+      rgba(35, 134, 54, 0.1) 45%,
+      transparent 90%
+    );
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.credits-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.credits-nav {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.credits-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background-color: rgba(48, 54, 61, 0.35);
+  border: 1px solid rgba(48, 54, 61, 0.65);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.credits-back:hover {
+  background-color: rgba(88, 166, 255, 0.15);
+  border-color: rgba(88, 166, 255, 0.6);
+  color: var(--accent-blue);
+}
+
+.credits-back-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.credits-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.credits-title {
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.credits-intro {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+.credits-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px 24px;
+  border-radius: 14px;
+  border: 1px solid rgba(48, 54, 61, 0.7);
+  background: rgba(22, 27, 34, 0.75);
+}
+
+.credits-section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.credits-section-description {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.credits-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+}
+
+.credits-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  background-color: rgba(13, 17, 23, 0.55);
+  border: 1px solid rgba(48, 54, 61, 0.6);
+}
+
+.credits-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.credits-role {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.credits-contribution {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.credits-empty {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.credits-footer {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 @media (max-width: 560px) {
   #root {
     padding: 36px 16px;
@@ -172,5 +339,18 @@ main.login-page {
 
   .login-title {
     font-size: 1.6rem;
+  }
+
+  main.credits-page {
+    max-width: 100%;
+  }
+
+  .credits-card {
+    padding: 32px 24px;
+    gap: 24px;
+  }
+
+  .credits-section {
+    padding: 18px 20px;
   }
 }

--- a/src/server/nrp-site/views/credits.pug
+++ b/src/server/nrp-site/views/credits.pug
@@ -1,0 +1,34 @@
+extends layout
+
+block layout-content
+  main.credits-page
+    section.credits-card
+      nav.credits-nav
+        a.credits-back(href="/")
+          span.credits-back-icon &larr;
+          span Back to login
+      header.credits-header
+        h1.credits-title Project Credits
+        if summary
+          p.credits-intro= summary
+      if creditsGroups && creditsGroups.length
+        each group in creditsGroups
+          section.credits-section
+            h2.credits-section-title= group.title
+            if group.description
+              p.credits-section-description= group.description
+            if group.members && group.members.length
+              ul.credits-list
+                each member in group.members
+                  li.credits-list-item
+                    span.credits-name= member.name
+                    if member.role
+                      span.credits-role= member.role
+                    if member.contribution
+                      p.credits-contribution= member.contribution
+            else
+              p.credits-empty Details coming soon.
+      else
+        p.credits-empty No credits available at this time.
+      footer.credits-footer
+        p Thank you to the GeoFS Naval Response Program community for their continued support.

--- a/src/server/nrp-site/views/index.pug
+++ b/src/server/nrp-site/views/index.pug
@@ -7,3 +7,5 @@ block layout-content
       h2.login-title GeoFS NRP Admin Site
       a.login-button(href="/login") Log in
       p.login-details For High Command officers and centralized governing members
+      footer.login-meta
+        a.login-credits-link(href="/credits") View project credits


### PR DESCRIPTION
## Summary
- add server-side data and a public route for a themed credits page
- create a credits view and styles that align with the existing login experience
- link the login screen to the new credits page for quick access

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c9d0bbd678832386a3777fa80397e8